### PR TITLE
gcc-10 fixes

### DIFF
--- a/src/dfb.c
+++ b/src/dfb.c
@@ -102,7 +102,7 @@ dfb_flip()
 }
 
 void
-dfb_flip_rect(x, y, w, h)
+dfb_flip_rect(int x, int y, int w, int h)
 {
    rect.x1 = x+opt.h_offset;
    rect.y1 = y+opt.v_offset;

--- a/src/directvnc.h
+++ b/src/directvnc.h
@@ -42,7 +42,7 @@
    Tight encoding assumes BUFFER_SIZE is at least 16384 bytes. */
 
 #define BUFFER_SIZE (640*480) 
-char buffer[BUFFER_SIZE];
+extern char buffer[BUFFER_SIZE];
 
 #define MAX_ENCODINGS 10
 
@@ -64,9 +64,9 @@ struct _mousestate
    unsigned int buttonmask;
 };
 
-struct _mousestate mousestate;
+extern struct _mousestate mousestate;
 
-int sock;
+extern int sock;
 
 /* rfb.c */
 int rfb_connect_to_server (char *server, int display);

--- a/src/main.c
+++ b/src/main.c
@@ -24,6 +24,11 @@
 #include <math.h>
 #include <signal.h>
 
+/* globals definitions */
+char buffer[BUFFER_SIZE];
+struct _mousestate mousestate;
+int sock;
+
 /* little convenience function */
 static inline double get_time(void);
 static inline void sig_handler(int foo) { exit(1); }


### PR DESCRIPTION
Fix build on gcc-10 (-fno-common change)

gcc-10 changed the default from -fcommon to fno-common:
  https://gcc.gnu.org/PR85678

As a result build fails as:

    ld: modmap.o:/build/directvnc/src/directvnc.h:45: multiple definition of
      `buffer'; main.o:/build/directvnc/src/directvnc.h:45: first defined here

The change moves variable definitions to .c files.